### PR TITLE
BILLINK-48 - Invoice plugin and error handling update

### DIFF
--- a/Gateway/Converter/ResponseConverter.php
+++ b/Gateway/Converter/ResponseConverter.php
@@ -56,7 +56,7 @@ class ResponseConverter implements \Magento\Payment\Gateway\Http\ConverterInterf
         } catch (\Exception $e) {
             $result = false;
             $this->logger->error('Could not convert Gateway Response. Error was: ' . $e->getMessage()
-                . ' ; Response was: ' . $response);
+                . ' ; Response was: ' . $data);
         }
 
         return ['result' => $result];

--- a/Gateway/Validator/AbstractResponseValidator.php
+++ b/Gateway/Validator/AbstractResponseValidator.php
@@ -48,7 +48,7 @@ abstract class AbstractResponseValidator extends \Magento\Payment\Gateway\Valida
         $response = $this->subjectReader->readResponse($validationSubject);
 
         try {
-            if (!$response->hasData()) {
+            if (!$response || !$response->hasData()) {
                 throw new InvalidResponseException('Could not retrieve any data from Billink service');
             }
 

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -218,6 +218,10 @@
         <plugin name="Billink_Billink_Plugin_OrderTotalsPlugin" type="Billink\Billink\Plugin\TotalsCollectorPlugin" />
     </type>
 
+    <type name="Magento\Sales\Model\Order\Email\Sender\InvoiceSender">
+         <plugin name="Billink\Billink\Plugin\InvoiceEmailSenderPlugin" type="Billink\Billink\Plugin\InvoiceEmailSenderPlugin" />
+    </type>
+
     <type name="\Billink\Billink\Gateway\Request\DeliveryAddressDataBuilder">
         <arguments>
             <argument name="checkoutSession" xsi:type="object">Magento\Checkout\Model\Session</argument>


### PR DESCRIPTION
- Invoice plugin di.xml is missing - restoring it
- Response converter incorrectly logs data.  is an object, while  is xml string, which should be logged
- In case we have error above ResponseValidator can retrieve incorrect  as 'false' and will threat it as an object - also fixing